### PR TITLE
Fix typo in API url in URL Breakdown

### DIFF
--- a/01.REST-API.md
+++ b/01.REST-API.md
@@ -14,7 +14,7 @@ We try to uphold RESTful principles in the API. Listing, showing and other non-s
 ## URL Breakdown
 
 ```
-https://api.gitter.im/v1/rooms/:roomId/chatMessage
+https://api.gitter.im/v1/rooms/:roomId/chatMessages
 ```
 
 * `https`: The GItter API is served over secure HTTP *only*.


### PR DESCRIPTION
Fix minor typo in the API URL Breakdown section.
/chatMessage → /chatMessages