### PR TITLE
fix large / lower case, litte typo fix

### DIFF
--- a/04.Messages-resource.md
+++ b/04.Messages-resource.md
@@ -31,7 +31,7 @@ All the parameters are optional:
  - `beforeId`: Get messages before `beforeId`.
  - `afterId`: Get messages after `afterId`.
  - `aroundId`: Get messages around `aroundId` including this message.
- - `limit`: maximum number of messages to return.
+ - `limit`: Maximum number of messages to return.
  - `q`: Search query.
 
 ```
@@ -111,7 +111,7 @@ GET /v1/rooms/:roomId/chatMessages?limit=50
 ```
 
 When you're ready to load the next page of results, find the ID of the oldest
-message in the previous result-set. In the previous example, this would be
+message in the previous result set. In the previous example, this would be
 "53316dc47bfc1a000000000f". Pass this ID through in the `beforeId` parameter, like
 this:
 
@@ -173,7 +173,7 @@ Send a message to a room.
 
 ### Parameters
 
- - `text`: **Required** body of the message.
+ - `text`: **Required** Body of the message.
 
 ```
 POST /v1/rooms/:roomId/chatMessages
@@ -225,7 +225,7 @@ Update a message.
 
 ### Parameters
 
- - `text`: **Required** body of the message.
+ - `text`: **Required** Body of the message.
 
 ```
 PUT /v1/rooms/:roomId/chatMessages/:chatMessageId


### PR DESCRIPTION
- fix large / lower case in sentences
- fix typo: ´result-set´ -> ´result set´