### PR TITLE
Join a room works for one-to-one chats too

### DIFF
--- a/03.Rooms-resource.md
+++ b/03.Rooms-resource.md
@@ -211,8 +211,9 @@ Try it from the CLI:
 To join a room you'll need to provide a URI for it. Said URI can represent a GitHub Org, a GitHub Repo or a Gitter Channel:
 
  - If the room exists and the user has enough permission to access it, it'll be added to the room.
+  - If the supplied URI is that of a Gitter user (e.g., `/someuser`), the API will create a one-to-one room.
  - If the room doesn't exist but the supplied URI represents a GitHub Org or GitHub Repo the user is an `admin` of, the room will be created automatically and the user added.
- - If the supplied URI is that of a gitter user (e.g., `/someuser`), the API will create a one-to-one room.
+ 
 
 ### Parameters
 

--- a/03.Rooms-resource.md
+++ b/03.Rooms-resource.md
@@ -212,6 +212,7 @@ To join a room you'll need to provide a URI for it. Said URI can represent a Git
 
  - If the room exists and the user has enough permission to access it, it'll be added to the room.
  - If the room doesn't exist but the supplied URI represents a GitHub Org or GitHub Repo the user is an `admin` of, the room will be created automatically and the user added.
+ - If the supplied URI is that of a gitter user (e.g., `/someuser`), the API will create a one-to-one room.
 
 ### Parameters
 


### PR DESCRIPTION
Make the doc a bit clearer about joining one-to-one chats via the API.

Ref: https://gitter.im/gitterHQ/developers?at=577679325c313d7521cc2655