### PR TITLE
Update join room docs

### DIFF
--- a/04.Rooms-resource.md
+++ b/04.Rooms-resource.md
@@ -139,6 +139,8 @@ To join a room you'll need to provide a URI for it. Said URI can represent a Git
 
 ### Parameters
 
+#### Step #1: Grab the room ID from URI
+
 - `uri`: **Required** URI of the room you would like to join.
 
 Try it from the CLI:
@@ -149,6 +151,32 @@ Try it from the CLI:
   "resource": "{{api_url}}/v1/rooms",
   "data": {
     "uri": "gitterhq/sandbox"
+  }
+}
+```
+
+which returns:
+
+```json
+{
+  "id": "52b42a52ed5ab0b3bf051b93",
+  "name": "gitterHQ/sandbox",
+  // ...
+}
+```
+
+#### Step #2: Join the room via ID
+
+- `id`: **Required** ID of the room you would like to join.
+
+Try it from the CLI:
+```
+'demo api-access';
+{
+  "verb": "post",
+  "resource": "{{api_url}}/v1/user/:userId/rooms",
+  "data": {
+    "id": "52b42a52ed5ab0b3bf051b93"
   }
 }
 ```


### PR DESCRIPTION
Update join room docs, see :point_up: [August 14, 2016 5:26 PM](https://gitter.im/gitterHQ/api?at=57b0f02d4073ee634d25c637)

Now a two-step process:

 1. Lookup room id via `v1/rooms` with `{ uri: 'foo' }`
 1. Join via `/v1/user/:userId/rooms` with `{ id: '1' }`