### PR TITLE
Add reference to `status` property of message

### DIFF
--- a/05.Messages-resource.md
+++ b/05.Messages-resource.md
@@ -18,6 +18,7 @@ Messages represent individual chat messages sent to a room. They are a sub-resou
  - `meta`: Metadata. This is currently not used for anything.
  - `v`: Version.
  - `gv`: Stands for "Gravatar version" and is used for cache busting.
+ - `status`: Boolean that indicates whether the message is a status update (a `/me` command)
 
 ## List Messages
 
@@ -174,6 +175,7 @@ Send a message to a room.
 ### Parameters
 
  - `text`: **Required** Body of the message.
+ - `status`: Boolean, set to true to indicate that the message is a status update (what `/me` uses)
 
 ```
 POST /v1/rooms/:roomId/chatMessages


### PR DESCRIPTION
By reading the [source code of `node-gitter`](https://github.com/gitterHQ/node-gitter/blob/master/lib/rooms.js#L74), I noticed that a message has a `status` property. This seemed to be missing in the documentation.