### PR TITLE
Add a link to documentation on how to create bots

### DIFF
--- a/09.Third-party-API-wrappers.md
+++ b/09.Third-party-API-wrappers.md
@@ -14,3 +14,9 @@ You can also access the Gitter API through one of the 3rd party libraries that m
 ## Go
 
 * [go-gitter](https://github.com/sromku/go-gitter) - Gitter API in Go.
+
+# Bots
+
+You can create Gitter bots to interact with on rooms.
+
+* [A tutorial on how to make a Gitter Bot](https://github.com/Odonno/gitter-bot-how-to) - documentation on how to host gitter bots on Heroku or Azure


### PR DESCRIPTION
I added a link to a repository where @gep13 and I explains how to create bots, currently using Heroku or Azure.

https://github.com/Odonno/gitter-bot-how-to
