### PR TITLE
Rename library name in "Third party api wrappers" page

### DIFF
--- a/09.Third-party-API-wrappers.md
+++ b/09.Third-party-API-wrappers.md
@@ -17,4 +17,4 @@ You can also access the Gitter API through one of the 3rd party libraries that m
 
 ## PHP
 
-* [gitter-api](https://github.com/SerafimArts/gitter-api) - Gitter API implementation for php 7.0+ allowing sync, async and streaming access.
+* [php-gitter](https://github.com/SerafimArts/gitter-api) - Gitter API implementation for php 7.0+ allowing sync, async and streaming access.


### PR DESCRIPTION
Rename library title (@MadLittleMods asked https://github.com/gitterHQ/docs/pull/48)